### PR TITLE
Add language support handler and Update dependencies

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-neon-messagebus-mq-connector~=0.3,>=0.3.5a6
+neon-messagebus-mq-connector~=0.3,>=0.3.5a8
 neon-mq-connector~=0.7,>=0.7.1a2
 ovos-messagebus~=0.0.3
 ovos_utils~=0.0.32


### PR DESCRIPTION
# Description
Refactor init to use a single `MessageBusClient` for the service
Add handler for `neon.languages.get` with unit test
Update messagebus-mq connector for language support and input handler fix

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->